### PR TITLE
Record 0001 as sent, and guard the NULL howto in 0002

### DIFF
--- a/patches/binutils/0001-ld-microblaze-don-t-index-the-local-symbol-cache.patch
+++ b/patches/binutils/0001-ld-microblaze-don-t-index-the-local-symbol-cache.patch
@@ -1,57 +1,38 @@
-From 531b63eb8dda80c6088b69f83215afa98ee8f1d5 Mon Sep 17 00:00:00 2001
+From e8cc70a5db534c877da3a6d138337810ad35388a Mon Sep 17 00:00:00 2001
 From: Samuel Price <thesamprice@gmail.com>
 Date: Thu, 6 Aug 2026 11:45:26 -0400
-Subject: [PATCH 1/4] microblaze: don't index the local symbol cache with a
- global symbol index
+Subject: [PATCH v2 1/1] ld: microblaze: don't index the local symbol cache
 
-microblaze_elf_relax_section walks the relocations of every other section
-of the BFD it is relaxing and, for R_MICROBLAZE_32, R_MICROBLAZE_32_NONE,
-R_MICROBLAZE_32_LO, R_MICROBLAZE_64, R_MICROBLAZE_TEXTREL_64 and
-R_MICROBLAZE_64_PCREL, does
+microblaze_elf_relax_section() was copied from sh_elf_relax_delete_bytes()
+in 2009 (7ba29e2a41) but the copy dropped a bounds check that was already
+present in the sh original.  This adds the missing two-line guard from
+bfd/elf32-sh.c:1227-1228, preventing an out-of-bounds read that silently
+corrupts relocation addends.
 
-	isym = isymbuf + ELF32_R_SYM (irelscan->r_info);
-	if (isym->st_shndx == shndx
-	    && ELF32_ST_TYPE (isym->st_info) == STT_SECTION)
-	  ...
-	  irelscan->r_addend -= calc_fixup (irelscan->r_addend, 0, sec);
+The bug: when scanning relocations in other sections, the code indexes
+isymbuf with a global symbol index without checking it against sh_info.
+isymbuf (from symtab_hdr->contents) holds only sh_info local symbols, so
+global symbol indices read past the end of the allocation.
 
-without checking the symbol index against symtab_hdr->sh_info.  isymbuf
-comes from symtab_hdr->contents, which by convention holds only the
-sh_info local symbols, so a relocation against a global symbol indexes
-past the end of the allocation.  The scan over the section being relaxed
-already has this guard; the scan over the other sections does not.
+If the out-of-bounds bytes happen to look like a local section symbol for
+the section being relaxed, the relocation's addend is incorrectly adjusted,
+losing 4 bytes per deleted IMM instruction.  This corrupts structure member
+accesses built at -O2:
 
-The adjustment is only ever meaningful for a reference made through the
-local section symbol of the section being relaxed, so relocations against
-global symbols can be skipped outright.
+	lwi rD, r0, sym + offsetof(struct s, member)
 
-Besides being an out-of-bounds read this silently miscompiles.  If the
-bytes past the end of the buffer happen to satisfy the two tests above,
-the addend of a relocation against a global symbol loses four bytes for
-every IMM the relaxation pass deleted below it.  Relocations with a zero
-addend are unaffected, so there is no link error; a structure member
-reference such as
+This was found as a silent miscompilation in RTEMS where
+Per_CPU_Control::executing was fetched as Per_CPU_Control::dispatch_necessary.
 
-	lwi rD, r0, sym + offsetof (struct s, member)
+The fix copies the guard from bfd/elf32-sh.c:1227-1228, present since the
+first binutils commit (252b5132c7, 1999-05-03).
 
-simply reads a neighbouring member.  This was found as a miscompilation
-of RTEMS built at -O2, where Per_CPU_Control::executing was fetched as
-Per_CPU_Control::dispatch_necessary.
+Three tests are added (the first for this target), checking that addends
+survive relaxation.  relax-addend.d and relax-addend-data.d use
+--gc-sections; relax-addend-eh.d uses .eh_frame editing (the route live on
+current master).
 
-symtab_hdr->contents is populated before relaxation by
-_bfd_elf_discard_section_eh_frame, via bfd_elf_discard_info; in the
-generic ELF emulation both run from the same after_allocation call, so
-the buffer is installed and read out of bounds within one call.
-
-Three tests are added, the first for this target.  All three check that an
-addend of 0x18 against a global survives relaxation of a sibling section
-that loses an IMM.  relax-addend.d and relax-addend-data.d reach the
-relaxation through --gc-sections and check the result with objdump and
-readelf respectively; relax-addend-eh.d reaches it through .eh_frame
-editing, which is the route that is live on current master.
-
-The tests behave differently depending on how ld was built, which is worth
-knowing when reading a result:
+Test behavior depends on how ld was built:
 
   ld built normally   all three pass with and without the fix, because
                       whether the out-of-bounds read corrupts the addend
@@ -63,10 +44,22 @@ knowing when reading a result:
 
 ld/testsuite results on microblaze-elf are otherwise unchanged.
 
+Alan Modra reviewed v1 and pointed out that none of the code in
+microblaze_elf_relax_section needs to re-read global symbols, so this
+version also reads only the sh_info local symbols rather than the whole
+symbol table, fails the relaxation rather than asserting if the read
+fails, uses PTR_ADD for the end of the local symbol buffer, and drops a
+dead assignment to isym before the global symbol loop.  isymbuf is left
+NULL when there are no local symbols, which is safe because every site
+that dereferences it is now gated on an index below sh_info.
+
 bfd/
 	* elf32-microblaze.c (microblaze_elf_relax_section): Skip
 	relocations against global symbols when scanning the relocations
-	of other sections.
+	of other sections.  Read only the local symbols, and fail rather
+	than assert if they cannot be read.  Use PTR_ADD when computing
+	the end of the local symbol buffer.  Remove a dead assignment to
+	isym before the global symbol loop.
 
 ld/
 	* testsuite/ld-microblaze/microblaze.exp: New file.
@@ -79,8 +72,39 @@ ld/
 	* testsuite/ld-microblaze/relax-addend-eh-support.s: New file.
 	* testsuite/ld-microblaze/relax-addend-eh.ld: New file.
 	* testsuite/ld-microblaze/relax-addend-eh.d: New test.
+
+Signed-off-by: Neal Frager <neal.frager@amd.com>
+Signed-off-by: Sam Price <samuel.r.price@nasa.gov>
+Assisted-by: Claude (Anthropic)
 ---
- bfd/elf32-microblaze.c                        |  3 +
+
+v1 -> v2:
+
+  Applied Alan Modra's suggested tidy-up verbatim: read only the sh_info
+  local symbols rather than the whole symbol table, fail rather than assert
+  if the read fails, use PTR_ADD for the end of the local symbol buffer, and
+  drop the dead assignment to isym before the global symbol loop.
+
+  No change to the guard hunk or to the ten test files from v1.  The commit
+  message is v1's with one paragraph added describing the above, and the
+  bfd/ ChangeLog entry extended to match.
+
+  Whole make check on microblaze-elf, pristine b7da195b94b versus this
+  patch, compared test by test:
+
+                  baseline              with patch
+    ld            473 pass, 4 fail      476 pass, 4 fail
+    gas           327 pass, 1 fail      327 pass, 1 fail
+    binutils      239 pass, 0 fail      239 pass, 0 fail
+
+  No test changes status in either direction and none disappears; the only
+  difference is the three new tests.  The four ld failures and the one gas
+  failure are pre-existing on this target and unrelated to this patch.
+
+  contrib/check_GNU_style.py is clean, and the patch applies to b7da195b94b
+  producing the tested tree.
+
+ bfd/elf32-microblaze.c                        | 18 +++--
  ld/testsuite/ld-microblaze/microblaze.exp     | 28 +++++++
  .../ld-microblaze/relax-addend-data.d         | 17 +++++
  .../ld-microblaze/relax-addend-eh-support.s   | 16 ++++
@@ -91,7 +115,7 @@ ld/
  ld/testsuite/ld-microblaze/relax-addend.d     | 26 +++++++
  ld/testsuite/ld-microblaze/relax-addend.ld    | 23 ++++++
  ld/testsuite/ld-microblaze/relax-addend.s     | 55 ++++++++++++++
- 11 files changed, 304 insertions(+)
+ 11 files changed, 312 insertions(+), 7 deletions(-)
  create mode 100644 ld/testsuite/ld-microblaze/microblaze.exp
  create mode 100644 ld/testsuite/ld-microblaze/relax-addend-data.d
  create mode 100644 ld/testsuite/ld-microblaze/relax-addend-eh-support.s
@@ -104,10 +128,29 @@ ld/
  create mode 100644 ld/testsuite/ld-microblaze/relax-addend.s
 
 diff --git a/bfd/elf32-microblaze.c b/bfd/elf32-microblaze.c
-index a52358a9..06cfb42c 100644
+index a52358a9a12..9afb1ccfdeb 100644
 --- a/bfd/elf32-microblaze.c
 +++ b/bfd/elf32-microblaze.c
-@@ -2084,6 +2084,9 @@ microblaze_elf_relax_section (bfd *abfd,
+@@ -1862,11 +1862,13 @@ microblaze_elf_relax_section (bfd *abfd,
+   /* Get symbols for this section.  */
+   symtab_hdr = &elf_symtab_hdr (abfd);
+   isymbuf = (Elf_Internal_Sym *) symtab_hdr->contents;
+-  symcount =  symtab_hdr->sh_size / sizeof (Elf32_External_Sym);
+-  if (isymbuf == NULL)
+-    isymbuf = bfd_elf_get_elf_syms (abfd, symtab_hdr, symcount,
+-				    0, NULL, NULL, NULL);
+-  BFD_ASSERT (isymbuf != NULL);
++  if (isymbuf == NULL && symtab_hdr->sh_info != 0)
++    {
++      isymbuf = bfd_elf_get_elf_syms (abfd, symtab_hdr, symtab_hdr->sh_info,
++				      0, NULL, NULL, NULL);
++      if (isymbuf == NULL)
++	goto error_return;
++    }
+ 
+   internal_relocs = _bfd_elf_link_read_relocs (abfd, sec, NULL, NULL, link_info->keep_memory);
+   if (internal_relocs == NULL)
+@@ -2084,6 +2086,9 @@ microblaze_elf_relax_section (bfd *abfd,
  	  irelscanend = irelocs + o->reloc_count;
  	  for (irelscan = irelocs; irelscan < irelscanend; irelscan++)
  	    {
@@ -117,9 +160,26 @@ index a52358a9..06cfb42c 100644
  	      if ((ELF32_R_TYPE (irelscan->r_info) == (int) R_MICROBLAZE_32)
  		  || (ELF32_R_TYPE (irelscan->r_info) == (int) R_MICROBLAZE_32_NONE))
  		{
+@@ -2285,7 +2290,7 @@ microblaze_elf_relax_section (bfd *abfd,
+ 	}
+ 
+       /* Adjust the local symbols defined in this section.  */
+-      isymend = isymbuf + symtab_hdr->sh_info;
++      isymend = PTR_ADD (isymbuf, symtab_hdr->sh_info);
+       for (isym = isymbuf; isym < isymend; isym++)
+ 	{
+ 	  if (isym->st_shndx == shndx)
+@@ -2297,7 +2302,6 @@ microblaze_elf_relax_section (bfd *abfd,
+ 	}
+ 
+       /* Now adjust the global symbols defined in this section.  */
+-      isym = isymbuf + symtab_hdr->sh_info;
+       symcount =  (symtab_hdr->sh_size / sizeof (Elf32_External_Sym)) - symtab_hdr->sh_info;
+       for (sym_index = 0; sym_index < symcount; sym_index++)
+ 	{
 diff --git a/ld/testsuite/ld-microblaze/microblaze.exp b/ld/testsuite/ld-microblaze/microblaze.exp
 new file mode 100644
-index 00000000..919fc2c2
+index 00000000000..919fc2c2a49
 --- /dev/null
 +++ b/ld/testsuite/ld-microblaze/microblaze.exp
 @@ -0,0 +1,28 @@
@@ -153,7 +213,7 @@ index 00000000..919fc2c2
 +}
 diff --git a/ld/testsuite/ld-microblaze/relax-addend-data.d b/ld/testsuite/ld-microblaze/relax-addend-data.d
 new file mode 100644
-index 00000000..c4b5232d
+index 00000000000..c4b5232d870
 --- /dev/null
 +++ b/ld/testsuite/ld-microblaze/relax-addend-data.d
 @@ -0,0 +1,17 @@
@@ -176,7 +236,7 @@ index 00000000..c4b5232d
 +#pass
 diff --git a/ld/testsuite/ld-microblaze/relax-addend-eh-support.s b/ld/testsuite/ld-microblaze/relax-addend-eh-support.s
 new file mode 100644
-index 00000000..d06df4b8
+index 00000000000..d06df4b83e8
 --- /dev/null
 +++ b/ld/testsuite/ld-microblaze/relax-addend-eh-support.s
 @@ -0,0 +1,16 @@
@@ -198,7 +258,7 @@ index 00000000..d06df4b8
 +gvar:	.space	64
 diff --git a/ld/testsuite/ld-microblaze/relax-addend-eh.d b/ld/testsuite/ld-microblaze/relax-addend-eh.d
 new file mode 100644
-index 00000000..d061fd04
+index 00000000000..d061fd04fb1
 --- /dev/null
 +++ b/ld/testsuite/ld-microblaze/relax-addend-eh.d
 @@ -0,0 +1,27 @@
@@ -231,7 +291,7 @@ index 00000000..d061fd04
 +#pass
 diff --git a/ld/testsuite/ld-microblaze/relax-addend-eh.ld b/ld/testsuite/ld-microblaze/relax-addend-eh.ld
 new file mode 100644
-index 00000000..c0d11cc9
+index 00000000000..c0d11cc9cb4
 --- /dev/null
 +++ b/ld/testsuite/ld-microblaze/relax-addend-eh.ld
 @@ -0,0 +1,9 @@
@@ -246,7 +306,7 @@ index 00000000..c0d11cc9
 +}
 diff --git a/ld/testsuite/ld-microblaze/relax-addend-eh.s b/ld/testsuite/ld-microblaze/relax-addend-eh.s
 new file mode 100644
-index 00000000..5900f8cc
+index 00000000000..5900f8cc956
 --- /dev/null
 +++ b/ld/testsuite/ld-microblaze/relax-addend-eh.s
 @@ -0,0 +1,76 @@
@@ -328,7 +388,7 @@ index 00000000..5900f8cc
 +	.4byte	0			/* terminator */
 diff --git a/ld/testsuite/ld-microblaze/relax-addend-support.s b/ld/testsuite/ld-microblaze/relax-addend-support.s
 new file mode 100644
-index 00000000..03d5eb0f
+index 00000000000..03d5eb0ffba
 --- /dev/null
 +++ b/ld/testsuite/ld-microblaze/relax-addend-support.s
 @@ -0,0 +1,24 @@
@@ -358,7 +418,7 @@ index 00000000..03d5eb0f
 +gvar:	.space	64
 diff --git a/ld/testsuite/ld-microblaze/relax-addend.d b/ld/testsuite/ld-microblaze/relax-addend.d
 new file mode 100644
-index 00000000..951c8737
+index 00000000000..951c8737696
 --- /dev/null
 +++ b/ld/testsuite/ld-microblaze/relax-addend.d
 @@ -0,0 +1,26 @@
@@ -390,7 +450,7 @@ index 00000000..951c8737
 +#pass
 diff --git a/ld/testsuite/ld-microblaze/relax-addend.ld b/ld/testsuite/ld-microblaze/relax-addend.ld
 new file mode 100644
-index 00000000..ca4d3603
+index 00000000000..ca4d3603989
 --- /dev/null
 +++ b/ld/testsuite/ld-microblaze/relax-addend.ld
 @@ -0,0 +1,23 @@
@@ -419,7 +479,7 @@ index 00000000..ca4d3603
 +}
 diff --git a/ld/testsuite/ld-microblaze/relax-addend.s b/ld/testsuite/ld-microblaze/relax-addend.s
 new file mode 100644
-index 00000000..16e50017
+index 00000000000..16e500170fb
 --- /dev/null
 +++ b/ld/testsuite/ld-microblaze/relax-addend.s
 @@ -0,0 +1,55 @@

--- a/patches/binutils/0002-microblaze-neutralise-relocations-against-discarded-.patch
+++ b/patches/binutils/0002-microblaze-neutralise-relocations-against-discarded-.patch
@@ -1,4 +1,4 @@
-From 3c2ae494cebbd1b376fa5fa45b3b06ad62f29709 Mon Sep 17 00:00:00 2001
+From 94f91c57d20bd82479c0fe22046d6f10dcb2aab4 Mon Sep 17 00:00:00 2001
 From: Samuel Price <thesamprice@gmail.com>
 Date: Thu, 6 Aug 2026 12:07:11 -0400
 Subject: [PATCH] microblaze: neutralise relocations against discarded sections
@@ -17,6 +17,10 @@ where zero is expected:
   ld-discard/zero-range
     regexp "^ 0000 (01)?000000(01)? (01)?000000(01)? 00000000 00000000 .*$"
     line   " 0000 00000000 00000002 00000000 00000000  ................"
+
+sym_hashes is checked for NULL exactly as RELOC_FOR_GLOBAL_SYMBOL does,
+because this lookup runs before that macro is reached and the macro
+documents the case as arising from erroneous input.
 
 Most backends put the check after symbol resolution and before the
 bfd_link_relocatable early exit.  This one resolves the symbol separately
@@ -48,16 +52,16 @@ bfd/
 	* elf32-microblaze.c (microblaze_elf_relocate_section): Look up
 	the section defining the symbol and neutralise relocations
 	against discarded sections, skipping relocation types with no
-	howto table entry.
+	howto table entry and objects with no symbol hash table.
 
 Signed-off-by: Sam Price <thesamprice@gmail.com>
 Assisted-by: Claude (Anthropic)
 ---
- bfd/elf32-microblaze.c | 33 +++++++++++++++++++++++++++++++++
- 1 file changed, 33 insertions(+)
+ bfd/elf32-microblaze.c | 35 +++++++++++++++++++++++++++++++++++
+ 1 file changed, 35 insertions(+)
 
 diff --git a/bfd/elf32-microblaze.c b/bfd/elf32-microblaze.c
-index 9afb1ccfdeb..effb2f71063 100644
+index 9afb1ccfdeb..96aa50532a0 100644
 --- a/bfd/elf32-microblaze.c
 +++ b/bfd/elf32-microblaze.c
 @@ -1063,6 +1063,7 @@ microblaze_elf_relocate_section (struct bfd_link_info *info,
@@ -68,7 +72,7 @@ index 9afb1ccfdeb..effb2f71063 100644
        const char *sym_name;
        bfd_reloc_status_type r = bfd_reloc_ok;
        const char *errmsg = NULL;
-@@ -1085,6 +1086,38 @@ microblaze_elf_relocate_section (struct bfd_link_info *info,
+@@ -1085,6 +1086,40 @@ microblaze_elf_relocate_section (struct bfd_link_info *info,
        howto = microblaze_elf_howto_table[r_type];
        r_symndx = ELF32_R_SYM (rel->r_info);
  
@@ -76,11 +80,13 @@ index 9afb1ccfdeb..effb2f71063 100644
 +	 against a section discarded by linkonce or comdat handling can
 +	 be neutralised.  The symbol is resolved separately in each of
 +	 the two branches below, so this has to be done here to cover
-+	 both the final and the relocatable link.  */
++	 both the final and the relocatable link.  sym_hashes is checked
++	 for NULL as RELOC_FOR_GLOBAL_SYMBOL does, since this runs before
++	 that macro is reached.  */
 +      sym_sec = NULL;
 +      if (r_symndx < symtab_hdr->sh_info)
 +	sym_sec = local_sections[r_symndx];
-+      else
++      else if (sym_hashes != NULL)
 +	{
 +	  struct elf_link_hash_entry *hd;
 +

--- a/patches/binutils/0002-microblaze-neutralise-relocations-against-discarded-.patch
+++ b/patches/binutils/0002-microblaze-neutralise-relocations-against-discarded-.patch
@@ -1,4 +1,4 @@
-From 5d5f6e82dc8e84db9abec0a571903c60f10fe6c3 Mon Sep 17 00:00:00 2001
+From 3c2ae494cebbd1b376fa5fa45b3b06ad62f29709 Mon Sep 17 00:00:00 2001
 From: Samuel Price <thesamprice@gmail.com>
 Date: Thu, 6 Aug 2026 12:07:11 -0400
 Subject: [PATCH] microblaze: neutralise relocations against discarded sections
@@ -26,17 +26,12 @@ The defining section is therefore looked up once before either branch,
 which covers both the final and the relocatable link without
 restructuring the function.
 
-microblaze_elf_howto_table is an array of howto pointers rather than an
-array of howtos, so it can contain NULL for a relocation type that is in
-range: R_MICROBLAZE_TEXTREL_32_LO (32) has no entry in
-microblaze_elf_howto_raw.  The type is reachable, since
-microblaze_elf_relax_section rewrites R_MICROBLAZE_TEXTREL_64 into it and
-microblaze_elf_relocate_section has a case for it, and _bfd_clear_contents
-reads howto->size, so the call is guarded.  elf32-ppc.c is the only other
-backend whose howto table is an array of pointers, and it likewise treats
-a NULL howto as a live case rather than dereferencing it.  A relocation of
-that type against a discarded section is therefore left alone rather than
-neutralised, which is the pre-existing behaviour.
+microblaze_elf_howto_table is an array of pointers, and
+R_MICROBLAZE_TEXTREL_32_LO has no entry in microblaze_elf_howto_raw, so
+howto can be NULL for a type that is in range.  Relaxation creates that
+type and _bfd_clear_contents reads howto->size, so the call is guarded, as
+elf32-ppc.c guards its own array of howto pointers.  Such a relocation is
+left alone rather than neutralised, as before.
 
 Fixes four existing tests on microblaze-elf:
 
@@ -58,11 +53,11 @@ bfd/
 Signed-off-by: Sam Price <thesamprice@gmail.com>
 Assisted-by: Claude (Anthropic)
 ---
- bfd/elf32-microblaze.c | 36 ++++++++++++++++++++++++++++++++++++
- 1 file changed, 36 insertions(+)
+ bfd/elf32-microblaze.c | 33 +++++++++++++++++++++++++++++++++
+ 1 file changed, 33 insertions(+)
 
 diff --git a/bfd/elf32-microblaze.c b/bfd/elf32-microblaze.c
-index 9afb1ccfdeb..2efb1015151 100644
+index 9afb1ccfdeb..effb2f71063 100644
 --- a/bfd/elf32-microblaze.c
 +++ b/bfd/elf32-microblaze.c
 @@ -1063,6 +1063,7 @@ microblaze_elf_relocate_section (struct bfd_link_info *info,
@@ -73,7 +68,7 @@ index 9afb1ccfdeb..2efb1015151 100644
        const char *sym_name;
        bfd_reloc_status_type r = bfd_reloc_ok;
        const char *errmsg = NULL;
-@@ -1085,6 +1086,41 @@ microblaze_elf_relocate_section (struct bfd_link_info *info,
+@@ -1085,6 +1086,38 @@ microblaze_elf_relocate_section (struct bfd_link_info *info,
        howto = microblaze_elf_howto_table[r_type];
        r_symndx = ELF32_R_SYM (rel->r_info);
  
@@ -101,12 +96,9 @@ index 9afb1ccfdeb..2efb1015151 100644
 +	    sym_sec = hd->root.u.def.section;
 +	}
 +
-+      /* microblaze_elf_howto_table is an array of pointers with a hole in
-+	 it: R_MICROBLAZE_TEXTREL_32_LO has no entry in
-+	 microblaze_elf_howto_raw, so howto is NULL for a relocation type
-+	 that is nonetheless in range.  _bfd_clear_contents reads
-+	 howto->size, so guard the call as elf32-ppc.c does when indexing
-+	 its own array of howto pointers.  */
++      /* howto is NULL for R_MICROBLAZE_TEXTREL_32_LO, which has no entry
++	 in microblaze_elf_howto_raw, and _bfd_clear_contents reads
++	 howto->size.  elf32-ppc.c guards its howto pointers the same way.  */
 +      if (sym_sec != NULL && discarded_section (sym_sec) && howto != NULL)
 +	RELOC_AGAINST_DISCARDED_SECTION (info, input_bfd, input_section,
 +					 rel, 1, relend, R_MICROBLAZE_NONE,

--- a/patches/binutils/0002-microblaze-neutralise-relocations-against-discarded-.patch
+++ b/patches/binutils/0002-microblaze-neutralise-relocations-against-discarded-.patch
@@ -1,8 +1,7 @@
-From 9c0e152119d06135c07a514517a8fb93f9380f99 Mon Sep 17 00:00:00 2001
+From 5d5f6e82dc8e84db9abec0a571903c60f10fe6c3 Mon Sep 17 00:00:00 2001
 From: Samuel Price <thesamprice@gmail.com>
 Date: Thu, 6 Aug 2026 12:07:11 -0400
-Subject: [PATCH 2/4] microblaze: neutralise relocations against discarded
- sections
+Subject: [PATCH] microblaze: neutralise relocations against discarded sections
 
 microblaze_elf_relocate_section does not handle relocations against
 symbols defined in sections discarded by linkonce or comdat handling.
@@ -27,6 +26,18 @@ The defining section is therefore looked up once before either branch,
 which covers both the final and the relocatable link without
 restructuring the function.
 
+microblaze_elf_howto_table is an array of howto pointers rather than an
+array of howtos, so it can contain NULL for a relocation type that is in
+range: R_MICROBLAZE_TEXTREL_32_LO (32) has no entry in
+microblaze_elf_howto_raw.  The type is reachable, since
+microblaze_elf_relax_section rewrites R_MICROBLAZE_TEXTREL_64 into it and
+microblaze_elf_relocate_section has a case for it, and _bfd_clear_contents
+reads howto->size, so the call is guarded.  elf32-ppc.c is the only other
+backend whose howto table is an array of pointers, and it likewise treats
+a NULL howto as a live case rather than dereferencing it.  A relocation of
+that type against a discarded section is therefore left alone rather than
+neutralised, which is the pre-existing behaviour.
+
 Fixes four existing tests on microblaze-elf:
 
   ld-discard/zero-range
@@ -41,13 +52,17 @@ in the other direction.
 bfd/
 	* elf32-microblaze.c (microblaze_elf_relocate_section): Look up
 	the section defining the symbol and neutralise relocations
-	against discarded sections.
+	against discarded sections, skipping relocation types with no
+	howto table entry.
+
+Signed-off-by: Sam Price <thesamprice@gmail.com>
+Assisted-by: Claude (Anthropic)
 ---
- bfd/elf32-microblaze.c | 30 ++++++++++++++++++++++++++++++
- 1 file changed, 30 insertions(+)
+ bfd/elf32-microblaze.c | 36 ++++++++++++++++++++++++++++++++++++
+ 1 file changed, 36 insertions(+)
 
 diff --git a/bfd/elf32-microblaze.c b/bfd/elf32-microblaze.c
-index 06cfb42c..c3a1c5bc 100644
+index 9afb1ccfdeb..2efb1015151 100644
 --- a/bfd/elf32-microblaze.c
 +++ b/bfd/elf32-microblaze.c
 @@ -1063,6 +1063,7 @@ microblaze_elf_relocate_section (struct bfd_link_info *info,
@@ -58,7 +73,7 @@ index 06cfb42c..c3a1c5bc 100644
        const char *sym_name;
        bfd_reloc_status_type r = bfd_reloc_ok;
        const char *errmsg = NULL;
-@@ -1085,6 +1086,35 @@ microblaze_elf_relocate_section (struct bfd_link_info *info,
+@@ -1085,6 +1086,41 @@ microblaze_elf_relocate_section (struct bfd_link_info *info,
        howto = microblaze_elf_howto_table[r_type];
        r_symndx = ELF32_R_SYM (rel->r_info);
  
@@ -86,7 +101,13 @@ index 06cfb42c..c3a1c5bc 100644
 +	    sym_sec = hd->root.u.def.section;
 +	}
 +
-+      if (sym_sec != NULL && discarded_section (sym_sec))
++      /* microblaze_elf_howto_table is an array of pointers with a hole in
++	 it: R_MICROBLAZE_TEXTREL_32_LO has no entry in
++	 microblaze_elf_howto_raw, so howto is NULL for a relocation type
++	 that is nonetheless in range.  _bfd_clear_contents reads
++	 howto->size, so guard the call as elf32-ppc.c does when indexing
++	 its own array of howto pointers.  */
++      if (sym_sec != NULL && discarded_section (sym_sec) && howto != NULL)
 +	RELOC_AGAINST_DISCARDED_SECTION (info, input_bfd, input_section,
 +					 rel, 1, relend, R_MICROBLAZE_NONE,
 +					 howto, 0, contents);

--- a/patches/binutils/README.md
+++ b/patches/binutils/README.md
@@ -163,6 +163,31 @@ in the `bfd_link_relocatable` branch with no NULL check, so `ld -r` on an object
 `TEXTREL_32_LO` against a section symbol dereferences NULL today, independent of 0002.
 Worth its own one-liner.
 
+### Fixed: 0002 could dereference a NULL `sym_hashes`
+
+The same shape of mistake, found by asking whether `sym_hashes[r_symndx - sh_info]` can go
+out of bounds.
+
+**The index cannot.** `_bfd_elf_link_info_read_relocs` routes every relocation through
+`elf_link_read_relocs_from_section`, which rejects `r_symndx >= NUM_SHDR_ENTRIES
+(symtab_hdr)` with a hard error (`bfd/elflink.c:2851-2864`). `elf_sym_hashes` is allocated
+with `symcount - sh_info` entries (`bfd/elflink.c:4864`), so `r_symndx - sh_info` is
+always inside it, and the subtraction cannot wrap because the `else` branch only runs when
+`r_symndx >= sh_info`. This is genuinely unlike 0001, where nothing tied the index range to
+the buffer length.
+
+**The pointer can.** `RELOC_FOR_GLOBAL_SYMBOL` (`bfd/elf-bfd.h:3431-3436`) — the macro
+every backend uses for this lookup — guards `sym_hashes == NULL` and documents it as
+arising from "erroneous or unsupported input (mixing a.out and elf in an archive, for
+example)". 0002 hoisted its own lookup to `:1101`, ahead of MicroBlaze's
+`RELOC_FOR_GLOBAL_SYMBOL` at `:1191`, and so outran that guard.
+
+Now `else if (sym_hashes != NULL)`, leaving `sym_sec` NULL so neutralisation is skipped and
+the later macro still returns false exactly as it does today.
+
+Both defects in 0002 are the same failure mode: moving work earlier in the function moves it
+ahead of a check that already existed further down.
+
 Raw `.sum` files: [`../../binutils-testsuite/`](../../binutils-testsuite/).
 
 ## Checks run on every patch

--- a/patches/binutils/README.md
+++ b/patches/binutils/README.md
@@ -12,34 +12,61 @@ git am .../0001-*.patch .../0002-*.patch .../0003-*.patch .../0004-*.patch
 Verified: the series applies to pristine master with `git am`, and the resulting tree is
 identical to the one tested.
 
+0001 and 0002 are re-verified against `b7da195b94b` in their current form: `git am` of
+0001 alone gives tree `07bc4db4a9`, and 0002 on top gives ld 480 passes / 0 unexpected
+failures. 0003 and 0004 have not been re-tested since 0001 changed.
+
 ## The patches
 
-| # | what | fixes |
-|---|---|---|
-| 0001 | don't index the local symbol cache with a global symbol index | the relaxation bug; adds 3 new tests |
-| 0002 | neutralise relocations against discarded sections | 4 existing tests |
-| 0003 | widen the `pr24511` xfail to all MicroBlaze targets | 1 existing test |
-| 0004 | write the value for `BFD_RELOC_8` and `BFD_RELOC_16` fixups | 2 existing tests |
+| # | what | fixes | status |
+|---|---|---|---|
+| 0001 | don't index the local symbol cache with a global symbol index | the relaxation bug; adds 3 new tests | **sent as v2, 2026-08-12** |
+| 0002 | neutralise relocations against discarded sections | 4 existing tests | ready; NULL howto guarded |
+| 0003 | widen the `pr24511` xfail to all MicroBlaze targets | 1 existing test | blocked: needs `#noxfail: microblaze*-linux*` |
+| 0004 | write the value for `BFD_RELOC_8` and `BFD_RELOC_16` fixups | 2 existing tests | not reviewed since 0001 |
+
+They are no longer sent as one series. 0001 went to the list on its own, as recommended
+below, and 0002 is now numbered as a standalone `[PATCH]` rather than `2/4`.
 
 **0001** is the substantive one and stands alone — it is the silent miscompilation
 documented in the rest of this repository. The other three are independent bugs found
 while testing it, and each can be taken or dropped separately.
 
-Two things to add to 0001 before sending:
+### 0001 status: sent as v2 (2026-08-12)
 
-- **Cite `bfd/elf32-sh.c:1227-1228`.** This function was copied from
-  `sh_elf_relax_delete_bytes()` in 2009, and sh has had character-for-character this
-  patch, in the same loop, since 1999. That is the strongest possible precedent and it is
-  currently missing from the commit message.
-- **Say that the `R_MICROBLAZE_32_SYM_OP_SYM` arm is dead code.** It is the only arm of
-  the five that is not gated on `STT_SECTION`, so a reviewer will read the guard as a
-  semantic change there. It is not: that `else if` at `:2120` is nested inside the
-  `R_MICROBLAZE_32 || R_MICROBLAZE_32_NONE` test at `:2087` and can never be true. Stating
-  it makes the patch provably a pure bounds fix. (The arm being dead is itself a separate
-  bug — see `RELAXATION-GUIDE.md` §7.4 — but not one this patch should try to fix.)
+Neal Frager posted v1 to binutils@sourceware.org on 2026-08-10,
+`<20260810060011.4186926-1-neal.frager@amd.com>`. Alan Modra reviewed it — "The patch
+looks good to me" — and suggested a tidy-up, on the grounds that no code in
+`microblaze_elf_relax_section` needs to re-read global symbols.
 
-The code hunk also lost the explanatory comment that `ANALYSIS.md` carries. Put two lines
-back; `isymbuf` holding only `sh_info` entries is not self-evident.
+v2 applies that tidy-up verbatim and was sent on 2026-08-12,
+`<20260813021826.84333-1-thesamprice@gmail.com>`, threaded under v1 and copied to Neal
+Frager, Alan Modra and Michael Eager. It:
+
+- reads only the `sh_info` local symbols rather than the whole symbol table;
+- fails the relaxation rather than asserting if the read fails;
+- uses `PTR_ADD` for the end of the local symbol buffer, since `isymbuf` may now be NULL;
+- drops the dead assignment to `isym` before the global symbol loop.
+
+The `sh` precedent is now cited in the commit message, including that the guard has been
+in `sh_elf_relax_delete_bytes` since the first binutils commit (`252b5132c7`,
+1999-05-03) — verified, not assumed.
+
+Two things were deliberately left out of the sent version, to keep it as close to v1 as
+possible. Add them if a reviewer asks:
+
+- **The `R_MICROBLAZE_32_SYM_OP_SYM` arm is dead code.** It is the only arm of the five
+  not gated on `STT_SECTION`, so a reviewer may read the guard as a semantic change
+  there. It is not: that `else if` is nested inside the
+  `R_MICROBLAZE_32 || R_MICROBLAZE_32_NONE` test above it and can never be true.
+- **An expanded comment on the `isymbuf` fetch**, recording that `symtab_hdr->contents`
+  holds only local symbols. Alan left that comment line untouched, so v2 does too;
+  `elf32-sh.c:573` likewise keeps a one-liner.
+
+Whole `make check` on `microblaze-elf`, pristine `b7da195b94b` versus v2, compared test
+by test: **zero status changes** in either direction, nothing disappeared, the only
+difference is the three new tests. ld 473→476 passes, gas 327/1 and binutils 239/0 both
+unchanged.
 
 **0002** — `bfd/elf32-microblaze.c` had no `RELOC_AGAINST_DISCARDED_SECTION`, the idiom
 60 other ELF backends use. Relocations into discarded linkonce sections survived and
@@ -100,16 +127,41 @@ With `#noxfail: microblaze*-linux*` added, `ld-elf/elf.exp` on `microblaze-xilin
 gives 327 expected passes and zero unexpected successes. **0003 should not be sent until
 this is applied.**
 
-### Known defect: 0002 can dereference a NULL howto
+### Fixed: 0002 could dereference a NULL howto
 
-`microblaze_elf_howto_table` (`bfd/elf32-microblaze.c:38`) is static and zero-filled, and
-`R_MICROBLAZE_TEXTREL_32_LO` (32) is the one in-range relocation type with **no HOWTO
-entry**. Patch 0002 passes `howto` straight to `_bfd_clear_contents`, which dereferences
-`howto->size` (`bfd/reloc.c:1331`). The type is reachable — relaxation rewrites
-`TEXTREL_64` into it at `:1987` and `relocate_section` handles it at `:1552` — so
-`-mpic-data-text-rel` code plus a discarded comdat section can crash the linker. Guard with
-`howto != NULL`, or supply the missing howto. Upstream is currently sensitive to
-crash-on-input bugs; this should be fixed before submission.
+`microblaze_elf_howto_table` (`bfd/elf32-microblaze.c:38`) is an array of *pointers*, not
+of howtos, and is zero-filled. `R_MICROBLAZE_TEXTREL_32_LO` (32) is the one in-range
+relocation type with **no HOWTO entry** — 33 entries in `microblaze_elf_howto_raw`
+against 34 slots. Patch 0002 passed `howto` straight to `_bfd_clear_contents`, which
+reads `howto->size` via `bfd_reloc_offset_in_range` (`bfd/reloc.c:1341`, `:529`). The
+type is reachable — relaxation rewrites `TEXTREL_64` into it and `relocate_section` has a
+case for it — so `-mpic-data-text-rel` code plus a discarded comdat section could crash
+the linker.
+
+0002 now guards the call with `howto != NULL`. **`elf32-ppc.c` is the model**: it and
+`elf32-mcore.c` are the only other backends whose howto table is an array of pointers,
+and ppc likewise treats a NULL howto as a live case rather than dereferencing it
+(`bfd/elf32-ppc.c:7639-7641`, `:7648`). Every other backend gets its howto by pointer
+arithmetic into a dense array of values — `elf32-sh.c:3486` is typical — so the hazard
+cannot arise there and those files offer no precedent.
+
+ppc also range-checks the index before the lookup; MicroBlaze already does that at
+`:1075`, so only the NULL handling was missing.
+
+Consequence: a relocation of that type against a discarded section is left alone rather
+than neutralised, which is the pre-existing behaviour. Supplying the missing HOWTO entry
+would be the fuller fix, but needs the correct field values and belongs in its own patch.
+
+Audited the other eleven uses of `microblaze_elf_howto_table` for the same hazard; all
+are safe. The two `->name` dereferences at `:1245` and `:1293` sit inside
+`case R_MICROBLAZE_SRO32` / `SRW32`, types 7 and 8, both of which have howtos, and the
+lazy-init check at `:1043` tests `R_MICROBLAZE_max-1` = 33 = `R_MICROBLAZE_32_NONE`,
+which has a howto.
+
+**Still open, and separate from this patch:** `:1151` does `if (!howto->partial_inplace)`
+in the `bfd_link_relocatable` branch with no NULL check, so `ld -r` on an object holding a
+`TEXTREL_32_LO` against a section symbol dereferences NULL today, independent of 0002.
+Worth its own one-liner.
 
 Raw `.sum` files: [`../../binutils-testsuite/`](../../binutils-testsuite/).
 
@@ -139,3 +191,9 @@ binutils@sourceware.org. Add your own `Signed-off-by:` before sending.
 Consider sending 0001 on its own first. It is a two-line fix with a reproducer and a
 clean testsuite; the other three are unrelated and can follow once it lands, rather than
 splitting reviewer attention across four problems with the same target.
+
+That is what happened: 0001 went out alone as v1 and then v2, and 0002 is next once 0001
+lands. Note that 0001 is signed off as `samuel.r.price@nasa.gov` (inherited from v1) while
+0002 uses `thesamprice@gmail.com`, which is the address that can send and receive list
+mail. Both are the same person and DCO does not require one address, but they are
+inconsistent across the two patches.


### PR DESCRIPTION
## What this does

Two things, both following from 0001 going to the binutils list.

### 0001 — now the v2 that was sent

Replaces the patch file with the exact v2 sent to `binutils@sourceware.org` on 2026-08-12 (`<20260813021826.84333-1-thesamprice@gmail.com>`), threaded under Neal's v1 and copied to Neal Frager, Alan Modra and Michael Eager. Renamed to match its new subject, which restores the `ld:` prefix v1 used.

Carries Alan Modra's suggested tidy-up **verbatim** — verified mechanically: applying his emailed diff on top of v1 produces a tree differing from ours only where his mail client turned tabs into spaces.

Commit message is v1's with one paragraph added and the `bfd/` ChangeLog extended. Everything else is byte-identical to what Neal posted.

### 0002 — standalone, and the NULL howto fixed

- renumbered `2/4` → `[PATCH]`
- adds the missing `Signed-off-by` and `Assisted-by` trailers
- guards the NULL howto defect the README recorded

`microblaze_elf_howto_table` is an array of *pointers* with exactly one hole — `R_MICROBLAZE_TEXTREL_32_LO`, 33 raw entries against 34 slots. 0002 passed that NULL to `_bfd_clear_contents`, which reads `howto->size`, so `-mpic-data-text-rel` plus a discarded comdat section could crash the linker.

**`elf32-ppc.c` is the model, not `elf32-sh.c`.** ppc and mcore are the only other backends whose howto table is an array of pointers, and ppc treats a NULL howto as a live case. Every other backend indexes a dense array of values where the hazard cannot arise — so the 60 files using `RELOC_AGAINST_DISCARDED_SECTION` offer no precedent here. ppc also range-checks the index; MicroBlaze already does, so only the NULL handling was missing.

## Verification

| | result |
|---|---|
| 0001 alone, `git am` onto `b7da195b94b` | tree `07bc4db4a9` |
| whole `make check` vs pristine baseline, test by test | **zero status changes**, nothing disappeared, +3 new tests |
| 0002 on top | ld **480 passes, 0 unexpected failures** |
| the four intended fixes | all `FAIL → PASS`, nothing else moved |
| `check_GNU_style.py`, `git diff --check` | clean |

Baseline reproduced the README's recorded numbers exactly (ld 473/4, gas 327/1, binutils 239/0), measured rather than assumed.

## What I did not do

- **`:1151` `howto->partial_inplace` has no NULL check** in the `bfd_link_relocatable` branch — a pre-existing NULL deref for `ld -r` on an object holding a `TEXTREL_32_LO` against a section symbol. Separate bug, recorded in the README rather than fixed here.
- **Supplying the missing HOWTO entry** — the fuller fix, but needs correct field values and its own patch. Consequence of the guard: such a relocation against a discarded section is left alone rather than neutralised, i.e. pre-existing behaviour.
- **`microblaze-xilinx-rtems7` and an ASan build** — everything above is `microblaze-elf` only.

## Worth a look

0001 is signed off as `samuel.r.price@nasa.gov` (inherited from v1) while 0002 uses `thesamprice@gmail.com`. Same person, DCO does not require one address, but they are inconsistent across the two patches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)